### PR TITLE
create projects and assign manager to projects

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,9 @@ import UpdateProgressBar from "./components/UpdateProgressBar";
 import { HomeNavBar } from "./components/homeNavBar";
 import SendContract from "./components/SendContract";
 import { TaskDashboard } from "./components/TaskDashboard";
-import { TaskScreen } from "./components/TaskScreen";;
+import { TaskScreen } from "./components/TaskScreen";
+import CreateProject from "./components/CreateProject";
+
 function App() {
   const [showNav, setShowNav] = useState(false);
 
@@ -97,7 +99,8 @@ function App() {
         </Route>
 		<Route path="/sendContract" element={<SendContract/>} />
         <Route path="*" element={<Navigate to ="/" />} /> 
-        <Route path='/progress' element={<UpdateProgressBar/>}/>
+        <Route path='/progress/:id' element={<UpdateProgressBar/>}/>
+        <Route path='/createproject' element={<CreateProject />} />
       </Routes>
     </Router>
     </div>

--- a/src/components/CreateProject.js
+++ b/src/components/CreateProject.js
@@ -1,0 +1,133 @@
+import React, {useState, useEffect} from 'react';
+import '../App.css'
+import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { getDatabase, ref, child, get, update } from "firebase/database";
+
+export default function CreateProject() {
+    const [uid, setUid] = useState(undefined);
+    const [customerUid, setCustomerUid] = useState(undefined);
+    const [customer, setCustomer] = useState(undefined);
+    const [signedInUser, setSignedInUser] = useState(undefined)
+    const [loading, setLoading] = useState(true);
+    const [message, setMessage] = useState("");
+    const [customerExists, setCustomerExists] = useState(false);
+    let auth = getAuth();
+
+    const getUserFromDb = async () => {
+        const dbRef = ref(getDatabase());
+        try{
+            const snapshot = await get(child(dbRef, `users/${uid}`));
+            if(snapshot.exists()) {
+                setSignedInUser(snapshot.val())
+            }
+        } catch(e) {
+            console.log(e);
+            console.log("user not found")
+        }
+    }
+
+    const getCustomerFromDb = async () => {
+        const dbRef = ref(getDatabase());
+        try{
+            const snapshot = await get(child(dbRef, `users/${customerUid}`));
+            if(snapshot.exists()) {
+                setCustomer(snapshot.val())
+                setCustomerExists(true);
+            } else {
+                //setMessage("User does not exist");
+                console.log("user does not exist");
+            }
+        } catch(e) {
+            console.log(e);
+            console.log("user not found")
+        }
+    }
+
+    useEffect(()=>{
+        onAuthStateChanged(auth, (user) => {
+            if(user){  
+                setLoading(false)
+                setUid(user.uid)
+            } else {
+                console.log("User not signed in");
+            }
+        });
+    }, [auth, uid])
+
+    useEffect(() => {
+        if(uid) {
+            getUserFromDb();
+        }
+    }, [uid, signedInUser])
+
+    useEffect(() => {
+        if(customerUid){
+            try{
+                getCustomerFromDb()
+                setMessage("Project successfully created")
+            } catch (e) {
+                setMessage("No user with that id")
+            }
+            
+        }
+    }, [customerUid]);
+
+    function handleProjectCreation(event){
+        /*let project = {
+            manager: uid,
+            step: 1,
+            customer: customerUid
+        };*/
+
+        event.preventDefault();
+        if(customerExists){
+            updateCustomerProject(customerUid, uid);
+            setLoading(false);
+        } else {
+            setMessage("User does not exist")
+        }
+    }
+
+    function updateCustomerProject(uid, project){
+        const db = getDatabase();
+
+        let updates = {};
+        updates['/users/' + uid + '/projectManager'] = project;
+        update(ref(db), updates);
+        return
+    }
+
+    if(loading){
+        return <div><h2>loading...</h2></div>
+    } else {
+
+        if(signedInUser && signedInUser.userType === "manager"){
+            //console.log(signedInUser.userType)
+            return (
+                <div className='register-container'>
+                    {message && <p>{message}</p>}
+                    <form onSubmit={handleProjectCreation} className="form">
+                        <div>
+                            <label className='label'>User Id</label>
+                            <input
+                                type="text"
+                                placeholder="uid"
+                                name="uid"
+                                className='input'
+                                onChange={(e) => setCustomerUid(e.target.value)}
+                            />
+                        </div>
+                        <button>Crete Project</button>
+                    </form>
+                    <a href="/login">Already have an account? Sign in here</a>
+                </div>
+            )
+        } else {
+            return (
+                <div>
+                    <p>You must be a manager to create a project</p>
+                </div>
+            )
+        }
+    }
+}

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -47,7 +47,7 @@ export default function RegisterForm() {
 
             const secretPass = "secretKey";
 
-            let userCredential = createUserWithEmailAndPassword(
+            createUserWithEmailAndPassword(
                 auth,
                 user.email,
                 user.password
@@ -88,7 +88,8 @@ export default function RegisterForm() {
             email: email,
             password: password,
             uid: uid,
-            step: 1
+            step: 1,
+            projectManager: ''
         })
     }
 


### PR DESCRIPTION
Going to http://localhost:3000/createproject should allow you to put in a uid and create a project for a user. Only a manager should be able to see the form. Only valid user ids should work, otherwise you should see an error message at the top of the screen. I currently have it so that a manager can create a project because I am struggling to find a way to assign the manager to the project without the manager being signed in, but we can try to change it to sales reps creating the projects later. 

I changed it so that to see the progress bar, you go to http://localhost:3000/progress/:id where :id is the user's id whose progress you wish to see. If you are a customer, you should only be able to see your progress. If you are a manager, you can see anyone's progress. If you are the manager assigned as project manager for that user, you should see a button to move the user forward in their project progress. If you are a new user and a manager has not created a project for you yet, you should see a page which says your project is not yet created.  

I had to change the format of the user in the database again so you will have to create new users to test this out. I am also currently getting warnings because of the way the useEffects are structured, so if anyone has input on how to stop that, that would be great. 